### PR TITLE
Fix crash on stop

### DIFF
--- a/src/countly.cpp
+++ b/src/countly.cpp
@@ -225,11 +225,6 @@ void Countly::startOnCloud(const std::string& app_key) {
 
 void Countly::stop() {
 	mutex.lock();
-	if (began_session) {
-		mutex.unlock();
-		endSession();
-		mutex.lock();
-	}
 	stop_thread = true;
 	mutex.unlock();
 	if (thread != nullptr && thread->joinable()) {
@@ -239,6 +234,9 @@ void Countly::stop() {
 			log(Countly::LogLevel::WARNING, "Could not join thread");
 		}
 		delete thread;
+	}
+	if (began_session) {
+		endSession();
 	}
 }
 


### PR DESCRIPTION
```cpp
void Countly::stop() {
	mutex.lock();
	if (began_session) {
		mutex.unlock();
		endSession();
		mutex.lock();
	}
	stop_thread = true;
	mutex.unlock();
	if (thread != nullptr && thread->joinable()) {
		try {
			thread->join();
		} catch(const std::system_error& e) {
			log(Countly::LogLevel::WARNING, "Could not join thread");
		}
		delete thread;
	}
}
```

After the ```stop``` method is called, the ```endSession``` method is called, but before it the ```mutex``` gets unlocked. 
After this unlocking the ```updateLoop``` method locks the ```mutex``` and calls the ```updateSession``` method. 
Something goes wrong.

Call stack:

```
 	vcruntime140d.dll!00007ffab07812d9()	Unknown
>	!std::char_traits<char>::move(char * const _First1, const char * const _First2, const unsigned __int64 _Count) Line 334	C++
 	!std::basic_string<char,std::char_traits<char>,std::allocator<char> >::append(const char * const _Ptr, const unsigned __int64 _Count) Line 2652	C++
 	!countly_curl_write_callback(void * data, unsigned __int64 byte_size, unsigned __int64 n_bytes, std::basic_string<char,std::char_traits<char>,std::allocator<char> > * body) Line 668	C++
 	!chop_write(connectdata * conn, int type, char * optr, unsigned __int64 olen) Line 582	C
 	!Curl_client_write(connectdata * conn, int type, char * ptr, unsigned __int64 len) Line 667	C
 	!Curl_httpchunk_read(connectdata * conn, char * datap, __int64 datalen, __int64 * wrotep, CURLcode * extrap) Line 201	C
 	!readwrite_data(Curl_easy * data, connectdata * conn, SingleRequest * k, int * didwhat, bool * done, bool * comeback) Line 797	C
 	!Curl_readwrite(connectdata * conn, Curl_easy * data, bool * done, bool * comeback) Line 1254	C
 	!multi_runsingle(Curl_multi * multi, curltime now, Curl_easy * data) Line 2150	C
 	!curl_multi_perform(Curl_multi * multi, int * running_handles) Line 2420	C
 	!easy_transfer(Curl_multi * multi) Line 603	C
 	!easy_perform(Curl_easy * data, bool events) Line 693	C
 	!curl_easy_perform(Curl_easy * data) Line 713	C
 	!Countly::sendHTTP(std::basic_string<char,std::char_traits<char>,std::allocator<char> > path, std::basic_string<char,std::char_traits<char>,std::allocator<char> > data) Line 735	C++
 	!Countly::endSession() Line 592	C++
 	!Countly::stop() Line 255	C++
```

![countly_curl_write_callback](https://user-images.githubusercontent.com/4709964/115957084-52b50c00-a522-11eb-817e-394d8eac8422.png)

![move](https://user-images.githubusercontent.com/4709964/115957090-59438380-a522-11eb-8637-5af63a2ce959.png)

The fix is to stop the ```updateLoop``` thread and only then call the ```endSession``` method.