### PR TITLE
Replace C++20 designated initializers in tests

### DIFF
--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -68,7 +68,7 @@ Countly::HTTPResponse fakeSendHTTP(bool use_post, const std::string& url, const 
 
 	http_call_queue.push_back(http_call);
 
-	Countly::HTTPResponse response { .success = false, .data = json::object() };
+	Countly::HTTPResponse response { false, json::object() };
 
 	if (http_call.url == "/i") {
 		response.success = true;


### PR DESCRIPTION
Using designated initializers a C++20 only feature so removing them. They don't bring much additional clarity to the code here  anyway so I don't believe removing them should be an issue.