### PR TITLE
Refactor member thread as unique_ptr

### DIFF
--- a/include/countly.hpp
+++ b/include/countly.hpp
@@ -249,39 +249,39 @@ private:
 
 	void updateLoop();
 
-	void (*logger_function)(LogLevel level, const std::string& message);
-	HTTPResponse (*http_client_function)(bool is_post, const std::string& url, const std::string& data);
+	void (*logger_function)(LogLevel level, const std::string& message) = logger_function;
+	HTTPResponse (*http_client_function)(bool is_post, const std::string& url, const std::string& data) = nullptr;
 
 	std::string host;
 
-	int port;
-	bool use_https;
-	bool always_use_post;
+	int port = 0;
+	bool use_https = false;
+	bool always_use_post = false;
 
-	bool began_session;
-	bool is_being_disposed;
-	bool is_sdk_initialized;
+	bool began_session = false;
+	bool is_being_disposed = false;
+	bool is_sdk_initialized = false;
 
 	std::chrono::system_clock::time_point last_sent_session_request;
 	
 	json session_params;
 	std::string salt;
 
-	std::thread *thread;
+	std::thread *thread = nullptr;
 	std::mutex mutex;
-	bool stop_thread;
-	bool running;
-	size_t wait_milliseconds;
+	bool stop_thread = false;
+	bool running = false;
+	size_t wait_milliseconds = COUNTLY_KEEPALIVE_INTERVAL;
 	unsigned short _auto_session_update_interval = 60; // value is in seconds;
 
-	size_t max_events;
+	size_t max_events = COUNTLY_MAX_EVENTS_DEFAULT;
 #ifndef COUNTLY_USE_SQLITE
 	std::deque<std::string> event_queue;
 #else
 	std::string database_path;
 #endif
 
-	bool remote_config_enabled;
+	bool remote_config_enabled = false;
 	json remote_config;
 };
 

--- a/include/countly.hpp
+++ b/include/countly.hpp
@@ -1,12 +1,13 @@
 #ifndef COUNTLY_HPP_
 #define COUNTLY_HPP_
 
-#include <iterator>
 #include <chrono>
+#include <iterator>
+#include <map>
+#include <memory>
+#include <mutex>
 #include <string>
 #include <thread>
-#include <mutex>
-#include <map>
 
 #ifndef COUNTLY_USE_SQLITE
 #include <deque>
@@ -267,7 +268,7 @@ private:
 	json session_params;
 	std::string salt;
 
-	std::thread *thread = nullptr;
+	std::unique_ptr<std::thread> thread;
 	std::mutex mutex;
 	bool stop_thread = false;
 	bool running = false;

--- a/src/countly.cpp
+++ b/src/countly.cpp
@@ -28,23 +28,7 @@ using json = nlohmann::json;
 #include "sqlite3.h"
 #endif
 
-Countly::Countly() : max_events(COUNTLY_MAX_EVENTS_DEFAULT), wait_milliseconds(COUNTLY_KEEPALIVE_INTERVAL) {
-	//Setting the default values
-	port = 0;
-	running = false;
-	use_https = false;
-	stop_thread = false;
-	began_session = false;
-	always_use_post = false;
-	is_being_disposed = false;
-	is_sdk_initialized = false;
-	remote_config_enabled = false;
-	
-	//Petting to null values
-	thread = nullptr;
-	logger_function = nullptr;
-	http_client_function = nullptr;
-
+Countly::Countly() {
 #if !defined(_WIN32) && !defined(COUNTLY_USE_CUSTOM_HTTP)
 	curl_global_init(CURL_GLOBAL_ALL);
 #endif

--- a/src/countly.cpp
+++ b/src/countly.cpp
@@ -338,7 +338,7 @@ void Countly::start(const std::string& app_key, const std::string& host, int por
 			stop_thread = false;
 
 			try {
-				thread = new std::thread(&Countly::updateLoop, this);
+				thread.reset(new std::thread(&Countly::updateLoop, this));
 			} catch(const std::system_error& e) {
 				std::ostringstream log_message;
 				log_message << "Could not create thread: " << e.what();
@@ -369,15 +369,14 @@ void Countly::_deleteThread() {
 	mutex.lock();
 	stop_thread = true;
 	mutex.unlock();
-	if (thread != nullptr && thread->joinable()) {
+	if (thread && thread->joinable()) {
 		try {
 			thread->join();
 		}
 		catch (const std::system_error& e) {
 			log(Countly::LogLevel::WARNING, "Could not join thread");
 		}
-		delete thread;
-		thread = nullptr;
+		thread.reset();
 	}
 }
 


### PR DESCRIPTION
Based on #57.

Using `unique_ptr` seems more appropriate. Also sorts includes.