### PR TITLE
refactor: use std::this_thread::sleep_for

### DIFF
--- a/examples/example_integration.cpp
+++ b/examples/example_integration.cpp
@@ -3,11 +3,6 @@
 #include <iostream>
 #include <random>
 #include <thread>
-#ifdef _WIN32
-#include <Windows.h>
-#else
-#include <unistd.h>
-#endif
 
 using namespace std;
 using namespace cly;
@@ -123,7 +118,7 @@ int main() {
       // Open a view
       std::string viewID = ct.views().openView("Main view", segmentation);
 
-      Sleep(2000); // two seconds
+      std::this_thread::sleep_for(2s);
 
       // Close an opened view
       ct.views().closeViewWithID(viewID);

--- a/tests/views.cpp
+++ b/tests/views.cpp
@@ -1,12 +1,11 @@
 #include "countly.hpp"
 #include "doctest.h"
-#ifdef _WIN32
-#include <Windows.h>
-#else
-#include <unistd.h>
-#endif
+
+#include <chrono>
+#include <thread>
 
 using namespace cly;
+using namespace std::literals::chrono_literals;
 
 /**
  * Validate view data.
@@ -65,7 +64,7 @@ TEST_CASE("recording views") {
       nlohmann::json s = e["segmentation"].get<nlohmann::json>();
       validateViewSegmentation(e, "view1", eid, 0, true, true);
 
-      Sleep(3000);
+      std::this_thread::sleep_for(3s);
       ct.views().closeViewWithName("view1");
       eventSize++;
       CHECK(ct.debugReturnStateOfEQ().size() == eventSize);
@@ -94,7 +93,7 @@ TEST_CASE("recording views") {
 
       validateViewSegmentation(e, "view1", eid, 0, true);
 
-      Sleep(2000);
+      std::this_thread::sleep_for(2s);
 
       ct.views().closeViewWithID(eid);
       eventSize++;
@@ -138,7 +137,7 @@ TEST_CASE("recording views") {
       CHECK(s["platform"].get<std::string>() == "ubuntu");
       CHECK(s["time"].get<std::string>() == "60");
 
-      Sleep(3000);
+      std::this_thread::sleep_for(3s);
 
       ct.views().closeViewWithName("view2");
       eventSize++;
@@ -173,7 +172,7 @@ TEST_CASE("recording views") {
       CHECK(s["platform"].get<std::string>() == "ubuntu");
       CHECK(s["time"].get<std::string>() == "60");
 
-      Sleep(1000);
+      std::this_thread::sleep_for(1s);
 
       ct.views().closeViewWithID(eid);
       eventSize++;


### PR DESCRIPTION
Use [`std::this_thread::sleep_for`](https://en.cppreference.com/w/cpp/thread/sleep_for) instead of `Sleep`. 

This fixes build errors on macOS `error: use of undeclared identifier 'Sleep'` when `COUNTLY_BUILD_TESTS=1` and `COUNTLY_BUILD_SAMPLE=1`.