### PR TITLE
Fix building on macOS

### DIFF
--- a/include/countly.hpp
+++ b/include/countly.hpp
@@ -217,12 +217,12 @@ private:
    * Helper methods to fetch remote config from the server.
    */
 #pragma region Remote_Config_Helper_Methods
-  void _fetchRemoteConfig(std::map<std::string, std::string> &data);
-  void _updateRemoteConfigWithSpecificValues(std::map<std::string, std::string> &data);
+  void _fetchRemoteConfig(std::map<std::string, std::string> data);
+  void _updateRemoteConfigWithSpecificValues(std::map<std::string, std::string> data);
 #pragma endregion Remote_Config_Helper_Methods
 
   void processRequestQueue();
-  void addToRequestQueue(std::string &data);
+  void addToRequestQueue(const std::string &data);
   HTTPResponse sendHTTP(std::string path, std::string data);
 
   void _changeDeviceIdWithMerge(const std::string &value);

--- a/src/countly.cpp
+++ b/src/countly.cpp
@@ -839,7 +839,7 @@ void Countly::processRequestQueue() {
   mutex.unlock();
 }
 
-void Countly::addToRequestQueue(std::string &data) {
+void Countly::addToRequestQueue(const std::string &data) {
   if (request_queue.size() >= 1000) {
     log(Countly::LogLevel::WARNING, "[Countly][addToRequestQueue] Request Queue is full. Dropping the oldest request.");
     request_queue.pop_front();
@@ -1063,7 +1063,7 @@ void Countly::enableRemoteConfig() {
   mutex.unlock();
 }
 
-void Countly::_fetchRemoteConfig(std::map<std::string, std::string> &data) {
+void Countly::_fetchRemoteConfig(std::map<std::string, std::string> data) {
   HTTPResponse response = sendHTTP("/o/sdk", serializeForm(data));
   mutex.lock();
   if (response.success) {
@@ -1095,7 +1095,7 @@ nlohmann::json Countly::getRemoteConfigValue(const std::string &key) {
   return value;
 }
 
-void Countly::_updateRemoteConfigWithSpecificValues(std::map<std::string, std::string> &data) {
+void Countly::_updateRemoteConfigWithSpecificValues(std::map<std::string, std::string> data) {
   HTTPResponse response = sendHTTP("/o/sdk", serializeForm(data));
   mutex.lock();
   if (response.success) {

--- a/src/logger_module.cpp
+++ b/src/logger_module.cpp
@@ -3,7 +3,7 @@
 namespace cly {
 class LoggerModule::LoggerModuleImpl {
 public:
-  LoggerModuleImpl::LoggerModuleImpl() {}
+  LoggerModuleImpl() {}
   LoggerFunction logger_function;
 };
 


### PR DESCRIPTION
First commit taken from #78.

Second commit fixes errors like:
```
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk/usr/include/c++/v1/thread:287:5: error: attempt to use a deleted function
    _VSTD::__invoke(_VSTD::move(_VSTD::get<1>(__t)), _VSTD::move(_VSTD::get<_Indices>(__t))...);
    ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk/usr/include/c++/v1/__config:858:15: note: expanded from macro '_VSTD'
#define _VSTD std::_LIBCPP_ABI_NAMESPACE
              ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk/usr/include/c++/v1/thread:298:12: note: in instantiation of function template specialization 'std::__thread_execute<std::unique_ptr<std::__thread_struct>, void (cly::Countly::*)(std::map<std::string, std::string> &), cly::Countly *, std::map<std::string, std::string>, 2UL, 3UL>' requested here
    _VSTD::__thread_execute(*__p.get(), _Index());
           ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk/usr/include/c++/v1/thread:314:54: note: in instantiation of function template specialization 'std::__thread_proxy<std::tuple<std::unique_ptr<std::__thread_struct>, void (cly::Countly::*)(std::map<std::string, std::string> &), cly::Countly *, std::map<std::string, std::string>>>' requested here
    int __ec = _VSTD::__libcpp_thread_create(&__t_, &__thread_proxy<_Gp>, __p.get());
                                                     ^
[redacted]/countly-sdk-cpp/src/countly.cpp:1087:15: note: in instantiation of function template specialization 'std::thread::thread<void (cly::Countly::*)(std::map<std::string, std::string> &), cly::Countly *, std::map<std::string, std::string> &, void>' requested here
  std::thread _thread(&Countly::_fetchRemoteConfig, this, data);
              ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk/usr/include/c++/v1/type_traits:1957:5: note: '~__nat' has been explicitly marked deleted here
    ~__nat() = delete;
    ^
1 error generated.
```

