### PR TITLE
updated example to prevent crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ int main(int argc, char *argv[]) {
 	Countly& ct = Countly::getInstance();
 	// OS, OS_version, device, resolution, carrier, app_version);
 	ct.SetMetrics("Windows 10", "10.22", "Mac", "800x600", "Carrier", "1.0");
+	ct.setDeviceID("mydevice");
 	ct.setCustomUserDetails({{"Account Type", "Basic"}, {"Employer", "Company4"}});
 	// Server and port
 	ct.Start("abf2034f975393fa994d1cf8adf9a93e4a29ac29", "https://myserver.com", 403);


### PR DESCRIPTION
While running the C++ SDK example code, I had the following crash:

`Countly::start` is calling `Countly::beginSession` which trying to get the device id via `session_params["device_id"].get<std::string>()` which crashes if it was not set beforehand.

I've tried to prevent the crash by checking the content of the `session_params` but the requests will start failing with `{"result":"Missing parameter \"app_key\" or \"device_id\""}` anyway, so I've added the call in the example.