### PR TITLE
Use condition_variable for interruptible thread sleep in updateLoop

### DIFF
--- a/include/countly.hpp
+++ b/include/countly.hpp
@@ -5,6 +5,7 @@
 #include "countly/countly_configuration.hpp"
 
 #include <chrono>
+#include <condition_variable>
 #include <functional>
 #include <iterator>
 #include <map>
@@ -349,6 +350,7 @@ private:
   bool enable_automatic_session = false;
   bool stop_thread = false;
   bool running = false;
+  std::condition_variable stop_cv; // Wakes updateLoop immediately on stop
   size_t wait_milliseconds = COUNTLY_KEEPALIVE_INTERVAL;
 
   size_t max_events = COUNTLY_MAX_EVENTS_DEFAULT;

--- a/src/countly.cpp
+++ b/src/countly.cpp
@@ -479,6 +479,7 @@ void Countly::_deleteThread() {
   mutex->lock();
   stop_thread = true;
   mutex->unlock();
+  stop_cv.notify_one();
   if (thread && thread->joinable()) {
     try {
       thread->join();
@@ -1193,15 +1194,17 @@ void Countly::updateLoop() {
   running = true;
   mutex->unlock();
   while (true) {
-    mutex->lock();
-    if (stop_thread) {
-      stop_thread = false;
-      mutex->unlock();
-      break;
+    {
+      std::unique_lock<std::mutex> lk(*mutex);
+      stop_cv.wait_for(lk, std::chrono::milliseconds(wait_milliseconds), [this] {
+        return stop_thread;
+      });
+      if (stop_thread) {
+        stop_thread = false;
+        running = false;
+        return;
+      }
     }
-    size_t last_wait_milliseconds = wait_milliseconds;
-    mutex->unlock();
-    std::this_thread::sleep_for(std::chrono::milliseconds(last_wait_milliseconds));
     if (enable_automatic_session == true && configuration->manualSessionControl == false) {
       updateSession();
     } else if (configuration->manualSessionControl == true) {


### PR DESCRIPTION
## Summary

- Replace `std::this_thread::sleep_for()` in `updateLoop()` with `std::condition_variable::wait_for()` 
- Add `stop_cv.notify_one()` in `_deleteThread()` to wake the sleeping thread immediately

This makes `stop()` return instantly instead of blocking for up to the full update interval (e.g. 30 seconds). Currently, `_deleteThread()` sets `stop_thread = true` and calls `thread->join()`, but the thread is stuck inside an uninterruptible `sleep_for()` and won't check the flag until the sleep finishes.

This causes GUI applications to hang for up to 30 seconds on quit when the SDK's static singleton destructor calls `stop()`.

## Changes

**`include/countly.hpp`**
- Added `#include <condition_variable>`
- Added `std::condition_variable stop_cv` member

**`src/countly.cpp`**
- `updateLoop()`: Replaced `sleep_for` with `stop_cv.wait_for()` using `stop_thread` as predicate
- `_deleteThread()`: Added `stop_cv.notify_one()` after setting `stop_thread = true`

## Test plan

- [x] Verified `stop()` returns instantly instead of blocking
- [x] Verified update interval behavior is unchanged during normal operation (same sleep duration unless notified)
- [x] No changes to public API